### PR TITLE
Resolved background color issue for delete button

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -5,7 +5,7 @@ export default function Button({ label, handlebutton, buttonLoading, bgColor }) 
     <button 
       type="button" 
       onClick={handlebutton} 
-      className={`py-2.5 px-5 me-2 mb-2 text-sm font-medium text-gray-900 focus:outline-none rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 ${bgColor}`}
+      className={`py-2.5 px-5 me-2 mb-2 text-sm font-medium text-gray-900 focus:outline-none rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:${bgColor} dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 ${bgColor}`}
     >
       {buttonLoading ? (
         <svg


### PR DESCRIPTION
className={`py-2.5 px-5 me-2 mb-2 text-sm font-medium text-gray-900 focus:outline-none rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:${bgColor} dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 ${bgColor}`}

-Initially in dark mode, grey color was used as background
-Updated it to use bgColor(passed as prop) in dark mode resolving the issue